### PR TITLE
Implement current power draw

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,12 @@ sha2 = "0.9"
 lazy-regex = "2.3"
 base64 = "0.13"
 scraper = "0.13"
+phf = { version="0", features=["macros"], optional=true }
 
 [features]
 vendored-openssl = ["openssl/vendored"]
 minerva = []
-antminer = []
+antminer = ["dep:phf"]
 whatsminer = []
 avalon = []
 all = ["minerva", "antminer", "whatsminer", "avalon"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,4 +58,6 @@ pub enum Error {
     NotSupported,
     #[error("Invalid response")]
     InvalidResponse,
+    #[error("Unknown model {0}")]
+    UnknownModel(String),
 }

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -61,6 +61,8 @@ pub trait Miner {
 
     async fn get_hashrate(&self) -> Result<f64, Error>;
 
+    async fn get_power(&self) -> Result<f64, Error>;
+
     async fn get_nameplate_rate(&self) -> Result<f64, Error>;
 
     async fn get_temperature(&self) -> Result<f64, Error>;
@@ -125,6 +127,10 @@ impl Miner for LockMiner {
 
     async fn get_hashrate(&self) -> Result<f64, Error> {
         self.miner.get_hashrate().await
+    }
+
+    async fn get_power(&self) -> Result<f64, Error> {
+        self.miner.get_power().await
     }
 
     async fn get_nameplate_rate(&self) -> Result<f64, Error> {

--- a/src/miners/avalon/avalon.rs
+++ b/src/miners/avalon/avalon.rs
@@ -67,6 +67,13 @@ impl Miner for Avalon {
         Ok(estats.ghs_mm / 1000.0)
     }
 
+    async fn get_power(&self) -> Result<f64, Error> {
+        let cmd = r#"{"command":"ascset","parameter":"0,hashpower"}"#;
+        let resp = self.client.send_recv(&self.ip, self.port, &cmd).await?;
+        let psinfo = cgminer::PowerSupplyInfo::try_from(serde_json::from_str::<cgminer::StatusResp>(&resp)?)?;
+        Ok(psinfo.power as f64)
+    }
+
     async fn get_nameplate_rate(&self) -> Result<f64, Error> {
         let cmd = r#"{"command":"version"}"#;
         let resp = self.client.send_recv(&self.ip, self.port, &cmd).await?;

--- a/src/miners/minerva/cgminer/hashboards.rs
+++ b/src/miners/minerva/cgminer/hashboards.rs
@@ -1,0 +1,28 @@
+use serde::Deserialize;
+
+fn deserialize_online<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    match s.as_str() {
+        "online" => Ok(true),
+        "offline" => Ok(false),
+        _ => Err(serde::de::Error::custom(format!("Unknown status code: {}", s))),
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Hashboard {
+    pub id: u32,
+    #[serde(rename = "status", deserialize_with = "deserialize_online")]
+    pub online: bool,
+    pub temperature: f32,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct HashBoardsResp {
+    pub code: usize,
+    pub message: String,
+    pub data: Option<Vec<Hashboard>>,
+}

--- a/src/miners/minerva/cgminer/mod.rs
+++ b/src/miners/minerva/cgminer/mod.rs
@@ -12,6 +12,8 @@ mod log;
 pub use log::*;
 mod led;
 pub use led::*;
+mod hashboards;
+pub use hashboards::*;
 
 use serde::Deserialize;
 

--- a/src/miners/whatsminer/whatsminer.rs
+++ b/src/miners/whatsminer/whatsminer.rs
@@ -155,6 +155,12 @@ impl Miner for Whatsminer {
         }
     }
 
+    async fn get_power(&self) -> Result<f64, Error> {
+        let resp = self.send_recv(&json!({"cmd":"summary"})).await?;
+        let sum: wmapi::SummaryResp = serde_json::from_str(&resp)?;
+        Ok(sum.summary[0].power as f64)
+    }
+
     async fn get_nameplate_rate(&self) -> Result<f64, Error> {
         let resp = self.send_recv(&json!({"cmd":"summary"})).await?;
         let hash: wmapi::SummaryResp = serde_json::from_str(&resp)?;


### PR DESCRIPTION
Whatsminers and Avalons report their current power draw.
Antminers are estimated based on datasheet efficiency for the model and real-time hashrate.
MinerVas are estimated based on MV7M datasheet efficiency (MinerVas offer no way to distinguish model size) and real-time hashrate.

Nameplate rate functions have been changed to report the current nominal hashrate for the miner, adjusted for the number of detected boards.
The caveat being all MinerVas report 90 nominally with all boards (again for reason above).
4-board MinerVas (which technically shouldn't exist anyway) with 1 board unplugged will incorrectly report its nominal hashrate as 90TH/s.